### PR TITLE
Fix of Date Formats in Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Each of them takes the value to format or parse and an optional formatter:
 "Jan 2, 2014 12:34:56 PM"
 
 (parse "2014-01-02T12:34:56.789") -> (datetime 2014 1 2 12 34 56 789)
-(parse "20140102" "YYYYmmDD") -> (datetime 2014 1 2)
+(parse "20140102" "YYYYMMdd") -> (datetime 2014 1 2)
 (parse "Jan 2, 2014 12:34:56 PM" :medium-date-time) -> (datetime 2014 1 2 12 34 56)
 ```
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Each of them takes the value to format or parse and an optional formatter:
 => (format (datetime 2014 1 2 12 34 56 789))
 "2014-01-02T12:34:56.789"
 
-=> (t/format (t/datetime 2014 1 2 12 34 56 789) "YYYYMMdd")
+=> (format (datetime 2014 1 2 12 34 56 789) "YYYYMMdd")
 "20140102"
 
 => (format (datetime 2014 1 2 12 34 56 789) :medium-date-time)

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ Each of them takes the value to format or parse and an optional formatter:
 => (format (datetime 2014 1 2 12 34 56 789))
 "2014-01-02T12:34:56.789"
 
-=> (format (datetime 2014 1 2 12 34 56 789) "YYYYmmDD")
-"20143402"
+=> (t/format (t/datetime 2014 1 2 12 34 56 789) "YYYYMMdd")
+"20140102"
 
 => (format (datetime 2014 1 2 12 34 56 789) :medium-date-time)
 "Jan 2, 2014 12:34:56 PM"


### PR DESCRIPTION
Examples used "YYYYmmDD", which is not YEAR|MONTH|DAY as expected. Changed these examples to use "YYYYMMdd" instead.